### PR TITLE
Update ImpulseDE2_main.R

### DIFF
--- a/R/ImpulseDE2_main.R
+++ b/R/ImpulseDE2_main.R
@@ -196,7 +196,7 @@ runImpulseDE2 <- function(
         if (boolVerbose) { message(strMessage) }
         strReport <- paste0(strReport, "\n", strMessage)
         # Extract count matrix if handed SummarizedExperiment
-        if (class(matCountData) == "SummarizedExperiment"){ 
+        if (inherits(matCountData, "SummarizedExperiment")){
             matCountData <- assay(matCountData)
         }
         lsProcessedData <- processData(


### PR DESCRIPTION
Updated for compatibility with R >4.0.0. Since R 4.0.0, matrices have two classes, "matrix" and "array", which leads to a "condition has length > 1" error when running `if (class(matCountData) == "SummarizedExperiment")`. The "inherits" or "is" functions should be used instead of "==" for checking the class (https://developer.r-project.org/Blog/public/2019/11/09/when-you-think-class.-think-again/index.html).